### PR TITLE
Fix: Preserve file permissions when packing binary executables

### DIFF
--- a/src/node/files.ts
+++ b/src/node/files.ts
@@ -146,15 +146,19 @@ export function getAllFiles(
   return fileList;
 }
 
+interface FileWithPermissions {
+  data: Uint8Array;
+  mode: number;
+}
 export interface GetAllFilesResult {
-  files: Record<string, Uint8Array>;
+  files: Record<string, FileWithPermissions>;
   ignoredCount: number;
 }
 
 export function getAllFilesWithCount(
   dirPath: string,
   baseDir: string = dirPath,
-  fileList: Record<string, Uint8Array> = {},
+  fileList: Record<string, FileWithPermissions> = {},
   additionalPatterns: string[] = [],
   ignoredCount = 0,
 ): GetAllFilesResult {
@@ -183,7 +187,10 @@ export function getAllFilesWithCount(
     } else {
       // Use forward slashes in zip file paths
       const zipPath = relativePath.split(sep).join("/");
-      fileList[zipPath] = readFileSync(filePath);
+      fileList[zipPath] = {
+        data: readFileSync(filePath),
+        mode: stat.mode,
+      };
     }
   }
 


### PR DESCRIPTION
## Problem

Binary executables were losing their execution permissions when packed into `.dxt` files. Files with `755` permissions (executable) were being extracted with `644` permissions (non-executable), breaking binary executables in Claude extensions.

> See #12 & #13

## Root Cause

The packing process was reading file contents but not preserving Unix file permissions in the ZIP archive. The `src/cli/pack.ts` file's `zipSync` function was being called without the necessary `ZipOptions` metadata to preserve permissions.

> _**IMPORTANT**_: I still believe that Claude Desktop is ignoring permissions metadata on extracted files. When I manually extract the `.dxt` file, the new binaries packaged by this PR's code **maintain Unix permissions** from the original files. When Claude Desktop Extensions extracts the `.dxt` and stores it in `.../Claude Extensions/...`, the binary file **continues to have lost** its `755`/`x` permissions.

## Solution

### Enhanced file collection to preserve permissions:
- Modified `getAllFilesWithCount()` to collect and store `stat.mode` permissions metadata alongside file data
- Updated `GetAllFilesResult` interface to include permission information

### Updated ZIP creation to store permissions:
- Added file permissions to ZIP external attributes using `fflate`'s `ZipOptions` (e.g. `attrs: (mode & 0o777) << 16`)
- Set `os: 3` (Unix) to enable Unix permission handling in ZIP format
- Added cross-platform compatibility (Unix vs Windows)

## Technical Details

- File permissions are stored in ZIP external attributes field following ZIP specification
- Unix permissions (0o755, 0o644, etc.) are bit-shifted to upper 16 bits as required by ZIP format
- Cross-platform support: Unix systems preserve permissions, Windows uses standard DOS attributes
- Verified correct bit manipulation: `0o755` → `493` → `32309248` (shifted)

## Testing

Confirmed that:
- ✅ File permissions are now correctly collected during packing
- ✅ Permissions are properly stored in ZIP external attributes
- ✅ Cross-platform compatibility works (Unix/Windows)
- ⚠️  **Limitation**: Claude Desktop's extraction process still ignores stored permissions

## Files Changed

- `src/node/files.ts` - Added permission-aware file collection functions
- `src/cli/pack.ts` - Updated ZIP creation to preserve file permissions

## Example Output

Before fix:
```bash
$ ls -la
total 26392
drwxr-xr-x@  6 ajohnson  staff       192 Jun 27 14:11 .
drwxr-xr-x  21 ajohnson  staff       672 Jun 27 10:04 ..
-rw-r--r--@  1 ajohnson  staff      6148 Jun 27 13:30 .DS_Store
-rw-r--r--@  1 ajohnson  staff      1692 Jun 26 17:58 fluree_favicon.png
-rw-r--r--@  1 ajohnson  staff      2179 Jun 27 10:31 manifest.json
-rwxr-xr-x@  1 ajohnson  staff  13495120 Jun 27 10:30 fluree-mcp-server
$ dxt pack
Validating manifest...
Manifest is valid!

📦  fluree-mcp-server@1.0.0
Archive Contents
   1.7kB fluree_favicon.png
   2.1kB manifest.json
  12.9MB fluree-mcp-server

Archive Details
name: fluree-mcp-server
version: 1.0.0
filename: fluree-mcp-server-1.0.0.dxt
package size: 5.0MB
unpacked size: 12.9MB
shasum: 08f5acb8b1c2dac8f383097fe999cab1f29b0b80
total files: 3
ignored (.dxtignore) files: 1

Output: /Users/ajohnson/fluree/fluree-mcp-server/assets/assets.dxt
$ unzip -o assets.dxt 
Archive:  assets.dxt
  inflating: fluree_favicon.png      
  inflating: manifest.json           
  inflating: fluree-mcp-server        
$ ls -la
total 36632
drwxr-xr-x@  7 ajohnson  staff       224 Jun 27 14:11 .
drwxr-xr-x  21 ajohnson  staff       672 Jun 27 10:04 ..
-rw-r--r--@  1 ajohnson  staff      6148 Jun 27 13:30 .DS_Store
-rw-r--r--@  1 ajohnson  staff   5242276 Jun 27 14:11 assets.dxt
-rw-r--r--@  1 ajohnson  staff      1692 Jun 27 14:11 fluree_favicon.png
-rw-r--r--@  1 ajohnson  staff      2179 Jun 27 14:11 manifest.json
-rw-r--r--@  1 ajohnson  staff  13495120 Jun 27 14:11 fluree-mcp-server 
```

> _**NOTE**_: the differences in `ls -la` outputs before/after `dxt pack`: `-rwxr-xr-x` vs `-rw-r--r--`

After fix:
```bash
(base) MacBook-Pro-7:assets ajohnson$ ls -la
total 26392
drwxr-xr-x@  6 ajohnson  staff       192 Jun 27 14:14 .
drwxr-xr-x  21 ajohnson  staff       672 Jun 27 10:04 ..
-rw-r--r--@  1 ajohnson  staff      6148 Jun 27 13:30 .DS_Store
-rw-r--r--@  1 ajohnson  staff      1692 Jun 27 14:11 fluree_favicon.png
-rw-r--r--@  1 ajohnson  staff      2179 Jun 27 14:11 manifest.json
-rwxr-xr-x@  1 ajohnson  staff  13495120 Jun 27 14:14 fluree-mcp-server
(base) MacBook-Pro-7:assets ajohnson$ node ~/fluree/dxt/dist/cli/cli.js pack
Validating manifest...
Manifest is valid!

📦  fluree-mcp-server@1.0.0
Archive Contents
   1.7kB fluree_favicon.png
   2.1kB manifest.json
  12.9MB fluree-mcp-server

Archive Details
name: fluree-mcp-server
version: 1.0.0
filename: fluree-mcp-server-1.0.0.dxt
package size: 5.0MB
unpacked size: 12.9MB
shasum: ad9cedd7456f9c88caa9804e90f41a948497ec95
total files: 3
ignored (.dxtignore) files: 1

Output: /Users/ajohnson/fluree/fluree-mcp-server/assets/assets.dxt
$ unzip -o assets.dxt 
Archive:  assets.dxt
  inflating: fluree_favicon.png      
  inflating: manifest.json           
  inflating: fluree-mcp-server        
$ ls -la
total 36632
drwxr-xr-x@  7 ajohnson  staff       224 Jun 27 14:14 .
drwxr-xr-x  21 ajohnson  staff       672 Jun 27 10:04 ..
-rw-r--r--@  1 ajohnson  staff      6148 Jun 27 13:30 .DS_Store
-rw-r--r--@  1 ajohnson  staff   5242276 Jun 27 14:14 assets.dxt
-rw-r--r--@  1 ajohnson  staff      1692 Jun 27 14:14 fluree_favicon.png
-rw-r--r--@  1 ajohnson  staff      2179 Jun 27 14:14 manifest.json
-rwxr-xr-x@  1 ajohnson  staff  13495120 Jun 27 14:14 fluree-mcp-server
```

> _**NOTE**_: the equivalence in `ls -la` outputs before/after `pack` with the PR updated build: `-rwxr-xr-x`

## Next Steps

While this PR fixes the packing side, Claude Desktop's extraction process needs to be updated to read and apply the stored permissions. The ZIP archives now contain all necessary permission metadata.

The `.dxt` format now properly preserves file permissions, making it ready for proper binary executable support once the extraction side is updated.