### PR TITLE
Add CI job for JSON schema validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,32 @@ jobs:
         run: yarn build
       - name: Test
         run: yarn lint && yarn test
+
+  validate-schemas:
+    name: Validate JSON Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22.17.x"
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build code (required for schema generation)
+        run: yarn build:code
+      - name: Generate schemas
+        run: yarn build:schema
+      - name: Check for schema changes
+        run: |
+          if ! git diff --exit-code schemas/; then
+            echo "Error: JSON schemas in schemas/ directory are out of sync!"
+            echo "Please run 'yarn build:schema' and commit the changes."
+            echo ""
+            echo "Changes detected:"
+            git diff schemas/
+            exit 1
+          fi
+          echo "✓ All schemas are up to date"


### PR DESCRIPTION
Add a new validate-schemas job to the CI workflow that ensures the committed JSON schemas in the schemas/ directory are up-to-date with the schema generation script. This prevents drift between the source code and generated schemas.

The job:
- Runs the schema generation script (yarn build:schema)
- Checks if any schemas were modified
- Fails if changes are detected, prompting developers to regenerate and commit the schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)