### PR TITLE
fix: revert to v0.2 manifest for Claude Desktop compatibility

### DIFF
--- a/schemas/mcpb-manifest-latest.schema.json
+++ b/schemas/mcpb-manifest-latest.schema.json
@@ -6,12 +6,12 @@
     },
     "dxt_version": {
       "type": "string",
-      "const": "0.3",
+      "const": "0.2",
       "description": "@deprecated Use manifest_version instead"
     },
     "manifest_version": {
       "type": "string",
-      "const": "0.3"
+      "const": "0.2"
     },
     "name": {
       "type": "string"
@@ -80,53 +80,11 @@
     "icon": {
       "type": "string"
     },
-    "icons": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "src": {
-            "type": "string"
-          },
-          "size": {
-            "type": "string",
-            "pattern": "^\\d+x\\d+$"
-          },
-          "theme": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "required": [
-          "src",
-          "size"
-        ],
-        "additionalProperties": false
-      }
-    },
     "screenshots": {
       "type": "array",
       "items": {
         "type": "string"
       }
-    },
-    "localization": {
-      "type": "object",
-      "properties": {
-        "resources": {
-          "type": "string",
-          "pattern": "\\$\\{locale\\}"
-        },
-        "default_locale": {
-          "type": "string",
-          "pattern": "^[A-Za-z0-9]{2,8}(?:-[A-Za-z0-9]{1,8})*$"
-        }
-      },
-      "required": [
-        "resources",
-        "default_locale"
-      ],
-      "additionalProperties": false
     },
     "server": {
       "type": "object",
@@ -354,13 +312,6 @@
           "description"
         ],
         "additionalProperties": false
-      }
-    },
-    "_meta": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": {}
       }
     }
   },

--- a/src/schemas/latest.ts
+++ b/src/schemas/latest.ts
@@ -1,1 +1,1 @@
-export * from "./0.3.js";
+export * from "./0.2.js";

--- a/src/schemas_loose/latest.ts
+++ b/src/schemas_loose/latest.ts
@@ -1,1 +1,1 @@
-export * from "./0.3.js";
+export * from "./0.2.js";

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -9,8 +9,10 @@ import { McpbManifestSchema as CurrentLooseManifestSchema } from "../schemas_loo
 
 /**
  * Latest manifest version - the version that new manifests should use
+ * Currently set to 0.2 for Claude Desktop compatibility
+ * (0.3 schema is available but not yet supported by Claude Desktop)
  */
-export const LATEST_MANIFEST_VERSION = "0.3" as const;
+export const LATEST_MANIFEST_VERSION = "0.2" as const;
 
 /**
  * Map of manifest versions to their strict schemas

--- a/test/icon-validation.test.ts
+++ b/test/icon-validation.test.ts
@@ -132,7 +132,7 @@ describe("Icon Validation", () => {
 
   function createTestManifest(filename: string, iconConfig: { icon?: string }) {
     const manifest = {
-      manifest_version: "0.3",
+      manifest_version: "0.2",
       name: "test-extension",
       version: "1.0.0",
       description: "Test extension for icon validation",

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -134,7 +134,7 @@ describe("McpbManifestSchema", () => {
       },
     };
 
-    const result = McpbManifestSchema.safeParse(fullManifest);
+    const result = v0_3.McpbManifestSchema.safeParse(fullManifest);
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -152,7 +152,7 @@ describe("McpbManifestSchema", () => {
 
     serverTypes.forEach((type) => {
       const manifest = {
-        manifest_version: "0.3",
+        manifest_version: "0.2",
         name: "test",
         version: "1.0.0",
         description: "Test",
@@ -270,7 +270,7 @@ describe("McpbManifestSchema", () => {
           default_locale: "en-US",
         },
       };
-      const result = McpbManifestSchema.safeParse(manifest);
+      const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(false);
       if (!result.success) {
         const messages = result.error.issues.map((issue) => issue.message);
@@ -286,7 +286,7 @@ describe("McpbManifestSchema", () => {
           default_locale: "en_us",
         },
       };
-      const result = McpbManifestSchema.safeParse(manifest);
+      const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(false);
     });
 
@@ -298,7 +298,7 @@ describe("McpbManifestSchema", () => {
           default_locale: "en-US",
         },
       };
-      const result = McpbManifestSchema.safeParse(manifest);
+      const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(true);
     });
   });
@@ -322,7 +322,7 @@ describe("McpbManifestSchema", () => {
         ...base,
         icons: [{ src: "assets/icon.png", size: "16", theme: "light" }],
       };
-      const result = McpbManifestSchema.safeParse(manifest);
+      const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(false);
     });
 
@@ -331,7 +331,7 @@ describe("McpbManifestSchema", () => {
         ...base,
         icons: [{ src: "assets/icon.png", size: "128x128" }],
       };
-      const result = McpbManifestSchema.safeParse(manifest);
+      const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(true);
     });
   });

--- a/test/valid-manifest.json
+++ b/test/valid-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "0.3",
+  "manifest_version": "0.2",
   "name": "test-extension",
   "display_name": "Test Extension",
   "version": "1.0.0",


### PR DESCRIPTION
## Problem

Current state (v1.1.5 published to npm):
- `mcpb pack` requires `manifest_version: "0.3"` 
- Claude Desktop v1.0.211 only supports v0.2 manifests
- **Result:** Users cannot pack bundles that work with Claude Desktop

This was introduced in PR #132 (commit 1640ade) when v0.3 schema with localization/theming was added.

## Solution

Revert `LATEST_MANIFEST_VERSION` back to `"0.2"` until Claude Desktop adds v0.3/v1.0 support.

### Changes:
- ✅ Set `LATEST_MANIFEST_VERSION = "0.2"` in `src/shared/constants.ts`
- ✅ Updated `src/schemas/latest.ts` to export v0.2 schema
- ✅ Updated `src/schemas_loose/latest.ts` to export v0.2 schema  
- ✅ Updated test files to use v0.2 or explicit v0_3 imports where needed
- ✅ All 109 tests passing
- ✅ No lint errors

## Testing

**Before fix (current v1.1.5):**
```bash
$ mcpb pack
ERROR: Manifest validation failed:
  - manifest_version: Invalid literal value, expected "0.3"
```

**After fix:**
```bash
$ mcpb pack
Validating manifest...
Manifest schema validation passes!
📦  Successfully packed
```

## Notes

- v0.3 schema remains available via explicit import: `import { v0_3 } from '@anthropic-ai/mcpb/schemas'`
- This is a **temporary compatibility fix** until Claude Desktop supports newer manifest versions
- Coordinates with @felixrieseberg

## Related

- PR #142 bumps to v1.0 but doesn't address Desktop compatibility