### PR TITLE
feat: add schema version option to init and pack commands

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -51,19 +51,32 @@ program
   .command("init [directory]")
   .description("Create a new MCPB extension manifest")
   .option("-y, --yes", "Accept all defaults (non-interactive mode)")
-  .action((directory?: string, options?: { yes?: boolean }) => {
-    void (async () => {
-      try {
-        const success = await initExtension(directory, options?.yes);
-        process.exit(success ? 0 : 1);
-      } catch (error) {
-        console.error(
-          `ERROR: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-        process.exit(1);
-      }
-    })();
-  });
+  .option(
+    "-s, --schema-version <version>",
+    "Schema version to use (0.1, 0.2, or 0.3)",
+  )
+  .action(
+    (
+      directory?: string,
+      options?: { yes?: boolean; schemaVersion?: string },
+    ) => {
+      void (async () => {
+        try {
+          const success = await initExtension(
+            directory,
+            options?.yes,
+            options?.schemaVersion,
+          );
+          process.exit(success ? 0 : 1);
+        } catch (error) {
+          console.error(
+            `ERROR: ${error instanceof Error ? error.message : "Unknown error"}`,
+          );
+          process.exit(1);
+        }
+      })();
+    },
+  );
 
 // Validate command
 program
@@ -88,22 +101,33 @@ program
 program
   .command("pack [directory] [output]")
   .description("Pack a directory into an MCPB extension")
-  .action((directory: string = process.cwd(), output?: string) => {
-    void (async () => {
-      try {
-        const success = await packExtension({
-          extensionPath: directory,
-          outputPath: output,
-        });
-        process.exit(success ? 0 : 1);
-      } catch (error) {
-        console.error(
-          `ERROR: ${error instanceof Error ? error.message : "Unknown error"}`,
-        );
-        process.exit(1);
-      }
-    })();
-  });
+  .option(
+    "-s, --schema-version <version>",
+    "Schema version to use (0.1, 0.2, or 0.3)",
+  )
+  .action(
+    (
+      directory: string = process.cwd(),
+      output?: string,
+      options?: { schemaVersion?: string },
+    ) => {
+      void (async () => {
+        try {
+          const success = await packExtension({
+            extensionPath: directory,
+            outputPath: output,
+            schemaVersion: options?.schemaVersion,
+          });
+          process.exit(success ? 0 : 1);
+        } catch (error) {
+          console.error(
+            `ERROR: ${error instanceof Error ? error.message : "Unknown error"}`,
+          );
+          process.exit(1);
+        }
+      })();
+    },
+  );
 
 // Unpack command
 program

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,7 +8,13 @@ import { McpbManifestSchema as LooseManifestSchemaV0_3 } from "../schemas_loose/
 import { McpbManifestSchema as CurrentLooseManifestSchema } from "../schemas_loose/latest.js";
 
 /**
- * Latest manifest version - the version that new manifests should use
+ * Default manifest version - the version that new manifests should use
+ * This is the version that most clients currently support
+ */
+export const DEFAULT_MANIFEST_VERSION = "0.2" as const;
+
+/**
+ * Latest manifest version - the newest version of the manifest schema
  */
 export const LATEST_MANIFEST_VERSION = "0.3" as const;
 
@@ -20,6 +26,13 @@ export const MANIFEST_SCHEMAS = {
   "0.2": ManifestSchemaV0_2,
   "0.3": ManifestSchemaV0_3,
 } as const;
+
+/**
+ * Valid manifest versions
+ */
+export const VALID_MANIFEST_VERSIONS = Object.keys(
+  MANIFEST_SCHEMAS,
+) as Array<keyof typeof MANIFEST_SCHEMAS>;
 
 /**
  * Map of manifest versions to their loose schemas (with passthrough)
@@ -39,3 +52,13 @@ export const LATEST_MANIFEST_SCHEMA = CurrentManifestSchema;
  * Get the latest loose manifest schema based on LATEST_MANIFEST_VERSION
  */
 export const LATEST_MANIFEST_SCHEMA_LOOSE = CurrentLooseManifestSchema;
+
+/**
+ * Get the default manifest schema based on DEFAULT_MANIFEST_VERSION
+ */
+export const DEFAULT_MANIFEST_SCHEMA = ManifestSchemaV0_2;
+
+/**
+ * Get the default loose manifest schema based on DEFAULT_MANIFEST_VERSION
+ */
+export const DEFAULT_MANIFEST_SCHEMA_LOOSE = LooseManifestSchemaV0_2;


### PR DESCRIPTION
Introduces a `—schema-version` flag for init and pack commands to allow users to specify which manifest schema version to use. Sets version 0.2 as the default since no clients currently support version 0.3.

- Added --schema-version option to mcpb init and mcpb pack commands
- Created DEFAULT_MANIFEST_VERSION constant set to "0.2"
- Updated LATEST_MANIFEST_VERSION to remain at "0.3" (newest schema)
- Both commands now default to schema version 0.2 instead of 0.3
- Added validation to ensure only valid versions (0.1, 0.2, 0.3) can be specified

Usage
```
# Create manifest with default 0.2 schema (client-supported)
mcpb init

# Create manifest with specific version
mcpb init --schema-version 0.3

# Pack with default 0.2 schema
mcpb pack

# Pack with specific version  
mcpb pack --schema-version 0.1
```