### PR TITLE
Fix: Restore type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anthropic-ai/mcpb",
   "description": "Tools for building MCP Bundles",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,6 @@
 // Browser-compatible exports
 export * from "./schemas/index.js";
+export * from "./shared/common.js";
 export * from "./shared/config.js";
 export * from "./shared/constants.js";
+export * from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,7 @@ export * from "./node/files.js";
 export * from "./node/sign.js";
 export * from "./node/validate.js";
 export * from "./schemas/index.js";
+export * from "./shared/common.js";
 export * from "./shared/config.js";
 export * from "./shared/constants.js";
+export * from "./types.js";

--- a/src/shared/common.ts
+++ b/src/shared/common.ts
@@ -13,3 +13,6 @@ export const McpbSignatureInfoSchema = z.strictObject({
   valid_to: z.string().optional(),
   fingerprint: z.string().optional(),
 });
+
+export type McpbSignatureInfo = z.infer<typeof McpbSignatureInfoSchema>;
+export type McpbUserConfigValues = z.infer<typeof McpbUserConfigValuesSchema>;


### PR DESCRIPTION
- Export McpbManifestAny and Logger types from types.js
- Export McpbSignatureInfo and McpbUserConfigValues from shared/common.ts
- Add exports to both main and browser entry points
