### PR TITLE
fix: upgrade node-forge to 1.3.2 to address security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anthropic-ai/mcpb",
   "description": "Tools for building MCP Bundles",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -89,7 +89,7 @@
     "fflate": "^0.8.2",
     "galactus": "^1.0.0",
     "ignore": "^7.0.5",
-    "node-forge": "^1.3.1",
+    "node-forge": "^1.3.2",
     "pretty-bytes": "^5.6.0",
     "zod": "^3.25.67",
     "zod-to-json-schema": "^3.24.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,7 @@ __metadata:
     galactus: "npm:^1.0.0"
     ignore: "npm:^7.0.5"
     jest: "npm:^29.7.0"
-    node-forge: "npm:^1.3.1"
+    node-forge: "npm:^1.3.2"
     prettier: "npm:^3.3.3"
     pretty-bytes: "npm:^5.6.0"
     ts-jest: "npm:^29.3.2"
@@ -4739,10 +4739,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
+"node-forge@npm:^1.3.2":
+  version: 1.3.3
+  resolution: "node-forge@npm:1.3.3"
+  checksum: 10c0/9c6f53b0ebb34865872cf62a35b0aef8fb337e2efc766626c2e3a0040f4c02933bf29a62ba999eb44a2aca73bd512c4eda22705a47b94654b9fb8ed53db9a1db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrades `node-forge` from 1.3.1 to ^1.3.2 
- Bumps version to 2.1.1
- Fixes 3 known security vulnerabilities:
  - [GHSA-554w-wpv2-vw27](https://github.com/advisories/GHSA-554w-wpv2-vw27): ASN.1 Unbounded Recursion (High 8.7)
  - [GHSA-5gfm-wpxj-wjgq](https://github.com/advisories/GHSA-5gfm-wpxj-wjgq): ASN.1 Validator Desynchronization (High 8.7)
  - [GHSA-65ch-62r8-g69g](https://github.com/advisories/GHSA-65ch-62r8-g69g): ASN.1 OID Integer Truncation (Medium 6.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)