### PR TITLE
fix: make mcp_config required for all server types in v0.4 schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anthropic-ai/mcpb",
   "description": "Tools for building MCP Bundles",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/schemas/mcpb-manifest-v0.4.schema.json
+++ b/schemas/mcpb-manifest-v0.4.schema.json
@@ -188,7 +188,8 @@
       },
       "required": [
         "type",
-        "entry_point"
+        "entry_point",
+        "mcp_config"
       ],
       "additionalProperties": false
     },

--- a/src/schemas/0.4.ts
+++ b/src/schemas/0.4.ts
@@ -37,8 +37,7 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
 export const McpbManifestServerSchema = z.strictObject({
   type: z.enum(["python", "node", "binary", "uv"]),
   entry_point: z.string(),
-  // mcp_config is optional for UV type (UV handles execution)
-  mcp_config: McpbManifestMcpConfigSchema.optional(),
+  mcp_config: McpbManifestMcpConfigSchema,
 });
 
 export const McpbManifestCompatibilitySchema = z.strictObject({


### PR DESCRIPTION
## Summary
- Make `mcp_config` required for all server types in the v0.4 schema, including `uv`