### PR TITLE
fix(Validation): Make "mcp_config" optional when using uv

### DIFF
--- a/schemas/mcpb-manifest-v0.4.schema.json
+++ b/schemas/mcpb-manifest-v0.4.schema.json
@@ -129,69 +129,130 @@
       "additionalProperties": false
     },
     "server": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "python",
-            "node",
-            "binary",
-            "uv"
-          ]
-        },
-        "entry_point": {
-          "type": "string"
-        },
-        "mcp_config": {
+      "anyOf": [
+        {
           "type": "object",
           "properties": {
-            "command": {
+            "entry_point": {
               "type": "string"
             },
-            "args": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "env": {
+            "mcp_config": {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "platform_overrides": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "command": {
-                    "$ref": "#/properties/server/properties/mcp_config/properties/command"
-                  },
-                  "args": {
-                    "$ref": "#/properties/server/properties/mcp_config/properties/args"
-                  },
-                  "env": {
-                    "$ref": "#/properties/server/properties/mcp_config/properties/env"
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "args": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
                   }
                 },
-                "additionalProperties": false
-              }
+                "env": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "platform_overrides": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "$ref": "#/properties/server/anyOf/0/properties/mcp_config/properties/command"
+                      },
+                      "args": {
+                        "$ref": "#/properties/server/anyOf/0/properties/mcp_config/properties/args"
+                      },
+                      "env": {
+                        "$ref": "#/properties/server/anyOf/0/properties/mcp_config/properties/env"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "command"
+              ],
+              "additionalProperties": false
+            },
+            "type": {
+              "type": "string",
+              "const": "python"
             }
           },
           "required": [
-            "command"
+            "entry_point",
+            "mcp_config",
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "entry_point": {
+              "$ref": "#/properties/server/anyOf/0/properties/entry_point"
+            },
+            "mcp_config": {
+              "$ref": "#/properties/server/anyOf/0/properties/mcp_config"
+            },
+            "type": {
+              "type": "string",
+              "const": "node"
+            }
+          },
+          "required": [
+            "entry_point",
+            "mcp_config",
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "entry_point": {
+              "$ref": "#/properties/server/anyOf/0/properties/entry_point"
+            },
+            "mcp_config": {
+              "$ref": "#/properties/server/anyOf/0/properties/mcp_config"
+            },
+            "type": {
+              "type": "string",
+              "const": "binary"
+            }
+          },
+          "required": [
+            "entry_point",
+            "mcp_config",
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "entry_point": {
+              "$ref": "#/properties/server/anyOf/0/properties/entry_point"
+            },
+            "mcp_config": {
+              "$ref": "#/properties/server/anyOf/0/properties/mcp_config"
+            },
+            "type": {
+              "type": "string",
+              "const": "uv"
+            }
+          },
+          "required": [
+            "entry_point",
+            "type"
           ],
           "additionalProperties": false
         }
-      },
-      "required": [
-        "type",
-        "entry_point",
-        "mcp_config"
-      ],
-      "additionalProperties": false
+      ]
     },
     "tools": {
       "type": "array",

--- a/src/schemas/0.4.ts
+++ b/src/schemas/0.4.ts
@@ -34,11 +34,20 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
     .optional(),
 });
 
-export const McpbManifestServerSchema = z.strictObject({
-  type: z.enum(["python", "node", "binary", "uv"]),
+const BaseServerSchema = z.strictObject({
   entry_point: z.string(),
   mcp_config: McpbManifestMcpConfigSchema,
 });
+
+export const McpbManifestServerSchema = z.discriminatedUnion("type", [
+  BaseServerSchema.extend({ type: z.literal("python") }),
+  BaseServerSchema.extend({ type: z.literal("node") }),
+  BaseServerSchema.extend({ type: z.literal("binary") }),
+  BaseServerSchema.extend({
+    type: z.literal("uv"),
+    mcp_config: McpbManifestMcpConfigSchema.optional(),
+  }),
+]);
 
 export const McpbManifestCompatibilitySchema = z.strictObject({
   claude_desktop: z.string().optional(),


### PR DESCRIPTION
## Motivation and Context

[Documentation states](https://github.com/modelcontextprotocol/mcpb/tree/main/examples/hello-world-uv#key-differences-from-python-runtime) that the `mcp_server` config variable should not be necessary when using `uv` as a server type. 

However, when attempting to compile a manifest without one, compilation failed with the following error message:


```
ERROR: Manifest validation failed:

  - server.mcp_config: Required
```

This was due to `mcp_config` being enforced in the schema for all server types. This PR makes `mcp_server` optional when the server type is set to `uv`.

## How Has This Been Tested?
This was tested locally by attempting to compile the following manifest.json:
```
{
  "manifest_version": "0.4",
  "name": "MCP Test",
  "version": "1.0.0",
  "description": "Description",
  "author": {
    "name": "Author"
  },
  "server": {
    "type": "uv",
    "entry_point": "src/server.py"
  },
  "tools": [
    {
      "name": "search_books"
    }
  ],
  "license": "MIT"
}
```

## Breaking Changes
No breaking changes.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
