### PR TITLE
[Documentation] Fix signature format documentation to match implementation

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -292,7 +292,8 @@ MCPB uses PKCS#7 (Cryptographic Message Syntax) for digital signatures:
 ```
 [Original MCPB ZIP content]
 MCPB_SIG_V1
-[Base64-encoded PKCS#7 signature]
+[4-byte little-endian length prefix]
+[DER-encoded PKCS#7 signature]
 MCPB_SIG_END
 ```
 


### PR DESCRIPTION
# Clarify the MCPB signature format in documentation

The signature format documentation in https://github.com/modelcontextprotocol/mcpb/blob/main/CLI.md#signature-structure currently shows a simplified format that doesn't match the actual implementation. This PR corrects the documentation to accurately describe the binary signature structure.

## Motivation and Context

The current documentation states that MCPB signatures use `[Base64-encoded PKCS#7 signature]`, but the actual implementation uses:
- A **4-byte little-endian length prefix** before the signature
- **DER-encoded (raw binary)** signatures, not Base64

This discrepancy causes issues for developers implementing MCPB signing outside of the official CLI. For example, Microsoft is integrating MCPB signing with our enterprise signing service (ESRP), and we discovered the documentation didn't match the actual format expected by `mcpb verify`.

The length prefix is essential because raw DER bytes could contain byte sequences that match `MCPB_SIG_END`, making parsing ambiguous without knowing the exact signature length.

## How Has This Been Tested?

- Verified by reading the source code in both the [TypeScript implementation](https://github.com/modelcontextprotocol/mcpb/blob/main/src/node/sign.ts#L220-L240) (`writeUInt32LE`/`readUInt32LE`) and the [C#/.NET implementation](https://github.com/asklar/mcpb/blob/user/asklar/dotnet/dotnet/mcpb/Commands/SignCommand.cs) (`BitConverter.GetBytes`/`BitConverter.ToInt32`)
- Signed MCPB files using the correct format outside of the MCPB CLI and verified them with the CLI's `mcpb verify` command.

## Breaking Changes

None. This is a documentation-only change that corrects the docs to match existing behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Current documentation (incorrect):**
```
[Original MCPB ZIP content]
MCPB_SIG_V1
[Base64-encoded PKCS#7 signature]
MCPB_SIG_END
```

**Proposed documentation (matches implementation):**
```
[Original MCPB ZIP content]
MCPB_SIG_V1
[4-byte little-endian length prefix]
[DER-encoded PKCS#7 signature]
MCPB_SIG_END
```