### PR TITLE
fix(examples/chrome-applescript): sanitize tab_id to prevent AppleScript injection

### DIFF
--- a/examples/chrome-applescript/server/index.js
+++ b/examples/chrome-applescript/server/index.js
@@ -82,12 +82,28 @@ class ChromeControlServer {
     }
   }
 
+  // Coerce tab_id to a safe numeric value before interpolating into
+  // AppleScript. inputSchema type:"number" is advisory — runtime may receive
+  // a string, which would otherwise be injected into the osascript template.
+  toSafeTabId(tabId) {
+    if (tabId === null || tabId === undefined) return null;
+    const n = Number.parseInt(tabId, 10);
+    if (Number.isNaN(n)) {
+      throw new Error("tab_id must be a number");
+    }
+    return n;
+  }
+
   async findTabById(tabId) {
+    const safeTabId = this.toSafeTabId(tabId);
+    if (safeTabId === null) {
+      return { w: null, t: null, found: false };
+    }
     const script = `
       tell application "Google Chrome"
         repeat with w in windows
           repeat with t in tabs of w
-            if (id of t as string) is "${tabId}" then
+            if (id of t as string) is "${safeTabId}" then
               return {w, t, true}
             end if
           end repeat
@@ -103,7 +119,8 @@ class ChromeControlServer {
     operation,
     successMessage = "Operation completed",
   ) {
-    if (!tabId) {
+    const safeTabId = this.toSafeTabId(tabId);
+    if (safeTabId === null) {
       // No tab ID, execute on active tab
       return this.executeAppleScript(operation.activeScript);
     }
@@ -112,7 +129,7 @@ class ChromeControlServer {
       tell application "Google Chrome"
         repeat with w in windows
           repeat with t in tabs of w
-            if (id of t as string) is "${tabId}" then
+            if (id of t as string) is "${safeTabId}" then
               ${operation.tabScript}
               return "${successMessage}"
             end if
@@ -551,6 +568,7 @@ class ChromeControlServer {
                 "JavaScript code is required and must be a string",
               );
             }
+            const safeTabId = this.toSafeTabId(tab_id);
 
             // Wrap the code to capture console.log outputs
             const wrappedCode = `
@@ -628,12 +646,13 @@ class ChromeControlServer {
 
             const escapedCode = this.escapeForAppleScript(wrappedCode);
 
-            const script = tab_id
-              ? `
+            const script =
+              safeTabId != null
+                ? `
               tell application "Google Chrome"
                 repeat with w in windows
                   repeat with t in tabs of w
-                    if (id of t as string) is "${tab_id}" then
+                    if (id of t as string) is "${safeTabId}" then
                       set result to execute t javascript "${escapedCode}"
                       return result
                     end if
@@ -642,7 +661,7 @@ class ChromeControlServer {
                 return "Tab not found"
               end tell
             `
-              : `
+                : `
               tell application "Google Chrome"
                 execute active tab of front window javascript "${escapedCode}"
               end tell
@@ -695,14 +714,16 @@ class ChromeControlServer {
 
           case "get_page_content": {
             const { tab_id } = args;
+            const safeTabId = this.toSafeTabId(tab_id);
 
             const jsCode = "document.body.innerText";
-            const script = tab_id
-              ? `
+            const script =
+              safeTabId != null
+                ? `
               tell application "Google Chrome"
                 repeat with w in windows
                   repeat with t in tabs of w
-                    if (id of t as string) is "${tab_id}" then
+                    if (id of t as string) is "${safeTabId}" then
                       set pageContent to execute t javascript "${jsCode}"
                       return pageContent
                     end if
@@ -711,7 +732,7 @@ class ChromeControlServer {
                 return "Tab not found"
               end tell
             `
-              : `
+                : `
               tell application "Google Chrome"
                 execute active tab of front window javascript "${jsCode}"
               end tell


### PR DESCRIPTION
## Summary

Sanitize `tab_id` before interpolating it into AppleScript strings in the `chrome-applescript` example.

The MCP SDK does not enforce `inputSchema` `type: "number"` at runtime, so a non-numeric string passed as `tab_id` would be interpolated directly into the `osascript` template and execute as AppleScript. A payload containing a quote character could break out of the `"${tab_id}"` literal and append arbitrary script.

Affected sites:
- `findTabById(tabId)`
- `executeTabOperation(tabId, ...)` — used by `close_tab`, `switch_to_tab`, `reload_tab`, `go_back`, `go_forward`
- `execute_javascript` handler
- `get_page_content` handler

## Fix

Added a `toSafeTabId()` helper on the server class that:
- Returns `null` for `null` / `undefined` (preserves the existing "no tab_id → active tab" fallthrough)
- Coerces via `Number.parseInt(tabId, 10)` and throws `tab_id must be a number` if the result is `NaN`

Call it at all four interpolation sites so the value reaching each template literal is always a `Number` (or the request errors out before the script is built). Thrown errors surface through the existing `try / catch` in the request handler, consistent with how the missing-`code` path in `execute_javascript` is already handled.

No version bump — this is a security fix to the example; the in-repo version is unchanged.

## Test plan

Static checks:

- [x] `node --check examples/chrome-applescript/server/index.js`
- [x] `yarn install && yarn lint` clean
- [x] Unit check of helper: numeric input → same number; `null` / `undefined` → `null`; string with leading digits → integer prefix only (the rest never reaches the template); non-numeric string → throws

Runtime checks (against a deployed build using the same `parseInt`-based sanitization contract):

- [x] `close_tab` with numeric `tab_id: 297209590` → `"Tab closed"`
- [x] `close_tab` with non-numeric `tab_id` → request rejected before `osascript` is constructed (`isError: true`)

Edge-case matrix (numeric inputs that pass the type check):

| Input | Observed behavior |
|-------|------------------|
| `0` | `"Tab not found"` (no match, no crash) |
| `-1` | `"Tab not found"` |
| `9999999999` (large int) | `"Tab not found"` (no overflow) |
| `1.5` (float — JSON `number` covers both) | `"Tab not found"` |
| `297209590` (already-closed tab) | `"Tab not found"` |

All numeric inputs reach the tab lookup step and return cleanly — no panic, no unexpected osascript side-effects. The shared helper pattern covers the five tab-ops handlers (`close_tab`, `switch_to_tab`, `reload_tab`, `go_back`, `go_forward`) via `executeTabOperation`, so behavior is identical across them.
