### PR TITLE
fix(examples/chrome-applescript): use JSON.stringify for AppleScript string interpolation

### DIFF
--- a/examples/chrome-applescript/server/index.js
+++ b/examples/chrome-applescript/server/index.js
@@ -33,17 +33,6 @@ class ChromeControlServer {
     this.setupHandlers();
   }
 
-  // Helper methods
-  escapeForAppleScript(str) {
-    if (typeof str !== "string") return str;
-    // Basic AppleScript string escaping
-    return str
-      .replace(/\\/g, "\\\\") // Escape backslashes first
-      .replace(/"/g, '\\"') // Then escape double quotes
-      .replace(/\n/g, "\\n") // Escape newlines
-      .replace(/\r/g, "\\r"); // Escape carriage returns
-  }
-
   async checkChromeAvailable() {
     try {
       const script = 'tell application "Google Chrome" to return "available"';
@@ -289,10 +278,23 @@ class ChromeControlServer {
               throw new Error("URL is required and must be a string");
             }
 
-            const escapedUrl = this.escapeForAppleScript(url);
+            try {
+              new URL(url);
+            } catch (error) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Error: url is not a valid url - ${error.message}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+
             const script = new_tab
-              ? `tell application "Google Chrome" to open location "${escapedUrl}"`
-              : `tell application "Google Chrome" to set URL of active tab of front window to "${escapedUrl}"`;
+              ? `tell application "Google Chrome" to open location ${JSON.stringify(url)}`
+              : `tell application "Google Chrome" to set URL of active tab of front window to ${JSON.stringify(url)}`;
 
             await this.executeAppleScript(script);
             return {
@@ -644,8 +646,6 @@ class ChromeControlServer {
               })();
             `;
 
-            const escapedCode = this.escapeForAppleScript(wrappedCode);
-
             const script =
               safeTabId != null
                 ? `
@@ -653,7 +653,7 @@ class ChromeControlServer {
                 repeat with w in windows
                   repeat with t in tabs of w
                     if (id of t as string) is "${safeTabId}" then
-                      set result to execute t javascript "${escapedCode}"
+                      set result to execute t javascript ${JSON.stringify(wrappedCode)}
                       return result
                     end if
                   end repeat
@@ -663,7 +663,7 @@ class ChromeControlServer {
             `
                 : `
               tell application "Google Chrome"
-                execute active tab of front window javascript "${escapedCode}"
+                execute active tab of front window javascript ${JSON.stringify(wrappedCode)}
               end tell
             `;
 


### PR DESCRIPTION
## Summary

Follow-up to #230. Replaces `escapeForAppleScript()` with `JSON.stringify()` at the two remaining AppleScript string-interpolation sites in `examples/chrome-applescript`: the `url` param in `open_url` and the `code` param in `execute_javascript` (via `wrappedCode`).

`escapeForAppleScript` only handled backslash, double quote, `\n`, and `\r` — tab, null, and other control characters passed through unescaped. `JSON.stringify` produces an RFC 8259–compliant quoted string that AppleScript parses as a string literal, covering the gaps.

Also adds `new URL(url)` validation to `open_url` so malformed URLs return `isError: true` instead of reaching `osascript`.

With those call sites migrated, `escapeForAppleScript` has no remaining callers and is deleted.

## Fix

- `open_url`: `"${escapeForAppleScript(url)}"` → `${JSON.stringify(url)}` (+ `new URL(url)` validity check before building the script)
- `execute_javascript`: `"${escapeForAppleScript(wrappedCode)}"` → `${JSON.stringify(wrappedCode)}` at both interpolation sites
- Delete unused `escapeForAppleScript` helper
- `tab_id` sanitization is unchanged (landed in #230)

## Test plan

- [x] `node --check examples/chrome-applescript/server/index.js`
- [x] `yarn install && yarn lint` clean
- [x] `grep -n escapeForAppleScript examples/chrome-applescript/server/index.js` → no matches
- [x] Manual: `open_url` with `url: "https://example.com/a\"b"` → navigates to `example.com/a%22b`; the `"` is percent-encoded as a literal URL character, not an `osascript` escape
- [x] Manual: `execute_javascript` with a `code` string containing `"`, `\t`, and `\\` → characters preserved as-is in the returned value
- [x] Manual: `open_url` with `url: "not a url"` → `isError: true`, `Invalid URL`

> **Note for reviewers:** testing `execute_javascript` requires Chrome's `View → Developer → Allow JavaScript from Apple Events` toggle to be enabled. Without it, the call to `execute t javascript` fails and is surfaced as a generic "Chrome not running" error via the existing outer `try/catch`. Not a change in this PR — documenting the prerequisite.
