### PR TITLE
fix: narrow over-broad default pack exclude patterns

### DIFF
--- a/src/node/files.ts
+++ b/src/node/files.ts
@@ -24,8 +24,14 @@ export const EXCLUDE_PATTERNS = [
   ".babelrc",
   ".pnp.*",
   "node_modules/.cache",
-  "node_modules/.bin",
-  "*.map",
+  // Match only source map files. A bare "*.map" also matches directories whose
+  // name ends in ".map" (for example es-iterator-helpers ships
+  // Iterator.prototype.map/), silently dropping their runtime code. See #241.
+  "*.js.map",
+  "*.cjs.map",
+  "*.mjs.map",
+  "*.css.map",
+  "*.ts.map",
   ".env.local",
   ".env.*.local",
   "npm-debug.log*",

--- a/test/mcpbignore.test.ts
+++ b/test/mcpbignore.test.ts
@@ -309,4 +309,102 @@ coverage/`;
       expect(shouldExclude("debug.log", additionalPatterns)).toBe(true);
     });
   });
+
+  // Regression tests for #241: the default exclude patterns used to be broad
+  // enough to drop real runtime code from the bundle.
+  describe("Default exclude patterns (issue #241)", () => {
+    it("should still exclude source map files by default", () => {
+      expect(shouldExclude("dist/index.js.map")).toBe(true);
+      expect(shouldExclude("dist/index.cjs.map")).toBe(true);
+      expect(shouldExclude("dist/index.mjs.map")).toBe(true);
+      expect(shouldExclude("dist/styles.css.map")).toBe(true);
+      expect(shouldExclude("dist/index.ts.map")).toBe(true);
+    });
+
+    it("should not exclude directories whose name ends in .map", () => {
+      // es-iterator-helpers ships directories such as Iterator.prototype.map/
+      // whose contents are real runtime code, not source maps.
+      expect(
+        shouldExclude(
+          "node_modules/es-iterator-helpers/Iterator.prototype.map",
+        ),
+      ).toBe(false);
+      expect(
+        shouldExclude(
+          "node_modules/es-iterator-helpers/Iterator.prototype.map/index.js",
+        ),
+      ).toBe(false);
+      expect(
+        shouldExclude(
+          "node_modules/es-iterator-helpers/Iterator.prototype.flatMap/index.js",
+        ),
+      ).toBe(false);
+    });
+
+    it("should not exclude a file that merely ends in .map", () => {
+      // A bare "*.map" matched these; only true source maps should be dropped.
+      expect(shouldExclude("data/world.map")).toBe(false);
+      expect(shouldExclude("src/site.map")).toBe(false);
+    });
+
+    it("should not exclude node_modules/.bin by default", () => {
+      // Some packages reference node_modules/.bin shims at module-load time.
+      expect(shouldExclude("node_modules/.bin")).toBe(false);
+      expect(shouldExclude("node_modules/.bin/retire")).toBe(false);
+    });
+
+    it("should still exclude node_modules/.cache by default", () => {
+      expect(shouldExclude("node_modules/.cache")).toBe(true);
+      expect(shouldExclude("node_modules/.cache/some-file")).toBe(true);
+    });
+  });
+
+  describe("getAllFiles default exclusions (issue #241)", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcpb-241-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("should keep .map-suffixed directories while dropping source maps", () => {
+      const pkgDir = path.join(
+        tempDir,
+        "node_modules",
+        "es-iterator-helpers",
+        "Iterator.prototype.map",
+      );
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, "index.js"), "module.exports = {};");
+
+      // A real source map sitting next to compiled output should still go away.
+      const distDir = path.join(tempDir, "dist");
+      fs.mkdirSync(distDir, { recursive: true });
+      fs.writeFileSync(path.join(distDir, "index.js"), "export default 1;");
+      fs.writeFileSync(path.join(distDir, "index.js.map"), "{}");
+
+      const files = getAllFiles(tempDir, tempDir, {}, []);
+      const fileNames = Object.keys(files);
+
+      expect(fileNames).toContain(
+        "node_modules/es-iterator-helpers/Iterator.prototype.map/index.js",
+      );
+      expect(fileNames).toContain("dist/index.js");
+      expect(fileNames).not.toContain("dist/index.js.map");
+    });
+
+    it("should keep node_modules/.bin shims", () => {
+      const binDir = path.join(tempDir, "node_modules", ".bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(path.join(binDir, "retire"), "#!/usr/bin/env node\n");
+
+      const files = getAllFiles(tempDir, tempDir, {}, []);
+      const fileNames = Object.keys(files);
+
+      expect(fileNames).toContain("node_modules/.bin/retire");
+    });
+  });
 });


### PR DESCRIPTION
The default EXCLUDE_PATTERNS in `mcpb pack` drop real runtime code from the bundle in two cases, so the packed `.mcpb` installs but crashes at module-load time.

**`*.map`** matches any path component ending in `.map`, including directories. Packages such as `es-iterator-helpers` ship directories named `Iterator.prototype.map/` and `Iterator.prototype.flatMap/` whose contents are ordinary `.js` files. The whole directory was excluded while sibling directories (`Iterator.prototype.filter/`, etc.) were kept, producing a `Cannot find module .../Iterator.prototype.map/index.js` error at startup. This change narrows the pattern to actual source maps: `*.js.map`, `*.cjs.map`, `*.mjs.map`, `*.css.map`, `*.ts.map`.

**`node_modules/.bin`** excluded all CLI shims. Some packages reference these at module-load time (for example `@salesforce/code-analyzer-retirejs-engine` calls `findCommand("retire")` at the top level of its `executor.js`) and throw if the shim is missing. Removing it from the defaults keeps the shims in the bundle. Users who do not want them can still add `node_modules/.bin` to their own `.mcpbignore`. `node_modules/.cache` stays excluded, since it only holds build caches.

Testing:
- Added regression tests in `test/mcpbignore.test.ts` asserting that source maps are still excluded, that `.map`-suffixed directories and their files are kept, and that `node_modules/.bin` shims are kept. Two of these use `getAllFiles` against a temp tree that reproduces the `es-iterator-helpers` layout.
- `yarn build`, `yarn lint`, and `yarn test` all pass (132 tests).

Fixes #241