### PR TITLE
Add npm source and issue metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@anthropic-ai/mcpb",
   "description": "Tools for building MCP Bundles",
   "version": "2.1.2",
+  "homepage": "https://github.com/modelcontextprotocol/mcpb#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/modelcontextprotocol/mcpb.git"
+  },
+  "bugs": {
+    "url": "https://github.com/modelcontextprotocol/mcpb/issues"
+  },
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
- add npm `homepage`, `repository`, and `bugs` metadata for `@anthropic-ai/mcpb`
- point package metadata at the current canonical `modelcontextprotocol/mcpb` repository and issue tracker

## Why
The currently published `@anthropic-ai/mcpb@2.1.2` package only returns `name` and `version` for:

```sh
npm view @anthropic-ai/mcpb@2.1.2 name version homepage repository bugs --json
```

Adding these fields makes the README, source repository, and issue tracker discoverable from npm and package metadata tools.

## Validation
```sh
npm view @anthropic-ai/mcpb@2.1.2 name version homepage repository bugs --json
node -e "const p=require('./package.json'); if(!p.homepage||!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.homepage); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts
git diff --check
```