### PR TITLE
Fix $-pattern corruption of user_config values in replaceVariables

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -34,7 +34,11 @@ export function replaceVariables(
             { key, replacement },
           );
         } else {
-          result = result.replace(pattern, replacement);
+          // Use a replacement function so that `$` sequences in the value
+          // (e.g. `$&`, `$$`, `$1`) are inserted literally rather than being
+          // interpreted as String.prototype.replace special patterns. This
+          // matters for secrets such as passwords that may contain `$`.
+          result = result.replace(pattern, () => replacement);
         }
       }
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -29,6 +29,15 @@ describe("replaceVariables", () => {
     consoleWarnSpy.mockRestore();
   });
 
+  it("should insert values containing $ patterns literally", () => {
+    // `$&`, `$$`, `$1` etc. are special in String.prototype.replace's
+    // replacement string — secrets containing them must be inserted verbatim.
+    const result = replaceVariables("${user_config.password}", {
+      "user_config.password": "pa$&ss$$wo$1rd",
+    });
+    expect(result).toBe("pa$&ss$$wo$1rd");
+  });
+
   it("should replace variables in objects", () => {
     const result = replaceVariables(
       { message: "Hello ${name}!" },


### PR DESCRIPTION
### Problem

`replaceVariables` substitutes `${user_config.*}` placeholders using `String.prototype.replace(pattern, replacement)`, where `replacement` is the raw user_config value. JavaScript treats `$` sequences in the replacement string as special patterns (`$$`, `$&`, `` $` ``, `$'`, `$n`), so any user_config value containing a `$` is silently corrupted before it reaches the MCP server's environment.

In practice this caused an MCP server to receive a mangled password and fail authentication with a generic 401, even though the user's credentials were correct. The password contained `$&`, which expands to the entire matched placeholder.

Fixes #258.

### Fix

Pass a replacement **function** to `replace`, which disables special-pattern interpretation and inserts the value verbatim:

```js
result = result.replace(pattern, () => replacement);
```

The array-expansion path already uses `push(replacement)` directly and was unaffected.

### Test

Adds a regression test asserting that a value containing `$&`, `$$` and `$n` is substituted literally. Verified that the test fails against the old `replace(pattern, replacement)` form and passes with the fix.

`yarn lint` and `yarn test` both pass.
