### PR TITLE
Skip directory entries when unpacking (fixes mcpb unpack on standard ZIP archives)

### DIFF
--- a/src/cli/unpack.ts
+++ b/src/cli/unpack.ts
@@ -93,6 +93,14 @@ export async function unpackExtension({
 
     for (const relativePath in decompressed) {
       if (Object.prototype.hasOwnProperty.call(decompressed, relativePath)) {
+        // Skip explicit directory entries (keys ending in "/"). ZIP archives
+        // produced by most tooling (e.g. `zip -r`) include these with empty
+        // data; writing to a path with a trailing slash fails and would abort
+        // the whole unpack. Needed parent directories are created below.
+        if (relativePath.endsWith("/")) {
+          continue;
+        }
+
         const data = decompressed[relativePath];
         const fullPath = join(finalOutputDir, relativePath);
 

--- a/test/unpack.test.ts
+++ b/test/unpack.test.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import { join } from "node:path";
+
+import { zipSync } from "fflate";
+
+import { unpackExtension } from "../src/cli/unpack";
+
+describe("unpackExtension", () => {
+  const tmpRoot = join(__dirname, "temp-unpack-dir-entries");
+  const mcpbPath = join(tmpRoot, "demo.mcpb");
+  const outDir = join(tmpRoot, "out");
+
+  beforeEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    fs.mkdirSync(tmpRoot, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("unpacks archives that contain explicit directory entries", () => {
+    // Standard ZIP tooling emits directory entries (keys ending in "/").
+    const archive = zipSync({
+      "manifest.json": new TextEncoder().encode("{}"),
+      "server/": new Uint8Array(0),
+      "server/index.js": new TextEncoder().encode("console.log('hi');"),
+    });
+    fs.writeFileSync(mcpbPath, archive);
+
+    const ok = unpackExtension({ mcpbPath, outputDir: outDir, silent: true });
+
+    return Promise.resolve(ok).then((result) => {
+      expect(result).toBe(true);
+      expect(fs.existsSync(join(outDir, "manifest.json"))).toBe(true);
+      expect(fs.existsSync(join(outDir, "server", "index.js"))).toBe(true);
+      // The directory entry must not be written as a file.
+      expect(fs.statSync(join(outDir, "server")).isDirectory()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`mcpb unpack` aborts on any archive containing explicit directory entries (keys ending in `/`). Standard ZIP tooling (`zip -r`, most language libraries) emits these, so unpack fails on the majority of real-world `.mcpb` files not produced by `mcpb pack` itself: the trailing-slash write fails with `ENOENT`/`EISDIR` and the throw aborts the whole extraction.

Fixes #261.

## Fix

Skip directory entries in the extraction loop (`src/cli/unpack.ts`). Needed parent directories are already created by the existing `mkdirSync`, so no functionality is lost.

## Test

Adds `test/unpack.test.ts`: builds a ZIP with a `server/` directory entry via fflate's `zipSync` and asserts unpack succeeds and extracts the nested file. Verified the test fails against the old code and passes with the fix. `yarn lint` and `yarn test` pass.