### PR TITLE
Escape regex metacharacters in the variable key during substitution

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -24,7 +24,12 @@ export function replaceVariables(
 
     // Replace all variables in the string
     for (const [key, replacement] of Object.entries(variables)) {
-      const pattern = new RegExp(`\\$\\{${key}\\}`, "g");
+      // Escape regex metacharacters in the key before building the pattern.
+      // Keys contain "." (e.g. "user_config.cs_password") and the manifest
+      // schema allows arbitrary user_config key names, so an unescaped key
+      // would over-match (any char for ".") or throw/ReDoS on a metacharacter.
+      const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const pattern = new RegExp(`\\$\\{${escapedKey}\\}`, "g");
 
       // Check if this pattern actually exists in the string
       if (result.match(pattern)) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -75,6 +75,26 @@ describe("replaceVariables", () => {
     const result = replaceVariables("Hello ${unknown}!", {});
     expect(result).toBe("Hello ${unknown}!");
   });
+
+  it("should treat '.' in the key as a literal, not a regex wildcard", () => {
+    // The "." must match only a literal dot. A template with a different
+    // character in that position must NOT be substituted.
+    const result = replaceVariables("${user_config_cs_password}", {
+      "user_config.cs_password": "SECRET",
+    });
+    expect(result).toBe("${user_config_cs_password}");
+  });
+
+  it("should not throw on keys containing regex metacharacters", () => {
+    // A user_config key with a metacharacter (e.g. "[") must not crash regex
+    // construction; it should match its own literal placeholder.
+    expect(() =>
+      replaceVariables("x ${a[b} y", { "a[b": "VALUE" }),
+    ).not.toThrow();
+    expect(replaceVariables("x ${a[b} y", { "a[b": "VALUE" })).toBe(
+      "x VALUE y",
+    );
+  });
 });
 
 describe("getMcpConfigForManifest", () => {


### PR DESCRIPTION
## Problem

`replaceVariables` builds its match pattern with `new RegExp(\`\\$\\{${key}\\}\`, "g")`, interpolating the raw key. Two consequences:

- The `.` in keys like `user_config.cs_password` is an unescaped metacharacter, so it matches *any* character — `${user_config_cs_password}` (underscore) is wrongly substituted.
- A `user_config` key containing a metacharacter (`[`, `(a+)+`, …) throws a `SyntaxError` / is a ReDoS vector, aborting `getMcpConfigForManifest` for an otherwise valid manifest. The schema allows arbitrary string keys.

Distinct from #258, which concerns `$` sequences in the replacement *value*. Fixes #262.

## Fix

Escape regex metacharacters in the key before constructing the pattern (`src/shared/config.ts`).

## Test

Adds two cases to `test/config.test.ts`: `.` matches only a literal dot, and a metacharacter key does not throw and matches its own literal placeholder. Both fail against the old code and pass with the fix. `yarn lint` + `yarn test` green.