### PR TITLE
Make server.mcp_config optional for uv server type (strict 0.4 schema)

### DIFF
--- a/src/schemas/0.4.ts
+++ b/src/schemas/0.4.ts
@@ -33,11 +33,23 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
     .optional(),
 });
 
-export const McpbManifestServerSchema = z.strictObject({
-  type: z.enum(["python", "node", "binary", "uv"]),
-  entry_point: z.string(),
-  mcp_config: McpbManifestMcpConfigSchema,
-});
+export const McpbManifestServerSchema = z
+  .strictObject({
+    type: z.enum(["python", "node", "binary", "uv"]),
+    entry_point: z.string(),
+    mcp_config: McpbManifestMcpConfigSchema.optional(),
+  })
+  .superRefine((server, ctx) => {
+    // mcp_config is optional only for the "uv" server type (the host manages
+    // execution — see MANIFEST.md). All other server types require it.
+    if (server.type !== "uv" && server.mcp_config === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["mcp_config"],
+        message: "Required",
+      });
+    }
+  });
 
 export const McpbManifestCompatibilitySchema = z.strictObject({
   claude_desktop: z.string().optional(),

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 
-import { v0_2, v0_3 } from "../src/schemas/index.js";
+import { v0_2, v0_3, v0_4 } from "../src/schemas/index.js";
 
 describe("McpbManifestSchema", () => {
   it("should validate a valid manifest", () => {
@@ -333,6 +333,41 @@ describe("McpbManifestSchema", () => {
       };
       const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("0.4 uv server mcp_config", () => {
+    const base = {
+      manifest_version: "0.4",
+      name: "uv-extension",
+      version: "1.0.0",
+      description: "UV extension",
+      author: { name: "Test Author" },
+      compatibility: { claude_desktop: "0.1.0" },
+    };
+
+    it("accepts a uv server with no mcp_config (host manages execution)", () => {
+      const manifest = {
+        ...base,
+        server: { type: "uv", entry_point: "main.py" },
+      };
+      const result = v0_4.McpbManifestSchema.safeParse(manifest);
+      expect(result.success).toBe(true);
+    });
+
+    it("still requires mcp_config for non-uv server types", () => {
+      const manifest = {
+        ...base,
+        server: { type: "node", entry_point: "server.js" },
+      };
+      const result = v0_4.McpbManifestSchema.safeParse(manifest);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const errors = result.error.issues.map((issue) =>
+          issue.path.join("."),
+        );
+        expect(errors).toContain("server.mcp_config");
+      }
     });
   });
 });


### PR DESCRIPTION
## Problem

MANIFEST.md (uv server type): "`mcp_config` is optional (host manages execution)". The loose 0.4 schema encodes this, but the **strict** schema — the one `validate` and `pack` use — still required `mcp_config`, so a spec-compliant UV extension without it is rejected (`server.mcp_config: Required`).

This is the same failure as #201, which was closed by adding `mcp_config` to the `hello-world-uv` example rather than fixing the schema, so the underlying contradiction remained. Fixes #263 (refs #201).

## Fix

In `src/schemas/0.4.ts`, make `mcp_config` optional and add a `superRefine` that still requires it for all non-`uv` server types — so strictness is preserved for node/python/binary while UV extensions validate.

## Test

Adds 0.4 cases to `test/schemas.test.ts`: a `uv` server with no `mcp_config` validates; a `node` server without it still errors at `server.mcp_config`. The uv-accept case fails against the old schema and passes with the fix. `yarn lint` + `yarn test` green.