### PR TITLE
Preserve unknown nested manifest keys in loose schemas (mcpb clean)

### DIFF
--- a/src/schemas_loose/0.1.ts
+++ b/src/schemas_loose/0.1.ts
@@ -2,22 +2,28 @@ import * as z from "zod";
 
 export const MANIFEST_VERSION = "0.1";
 
-export const McpServerConfigSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+export const McpServerConfigSchema = z
+  .object({
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
 
-export const McpbManifestAuthorSchema = z.object({
-  name: z.string(),
-  email: z.string().email().optional(),
-  url: z.string().url().optional(),
-});
+export const McpbManifestAuthorSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().email().optional(),
+    url: z.string().url().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestRepositorySchema = z.object({
-  type: z.string(),
-  url: z.string().url(),
-});
+export const McpbManifestRepositorySchema = z
+  .object({
+    type: z.string(),
+    url: z.string().url(),
+  })
+  .passthrough();
 
 export const McpbManifestPlatformOverrideSchema =
   McpServerConfigSchema.partial();
@@ -28,11 +34,13 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
     .optional(),
 });
 
-export const McpbManifestServerSchema = z.object({
-  type: z.enum(["python", "node", "binary"]),
-  entry_point: z.string(),
-  mcp_config: McpbManifestMcpConfigSchema,
-});
+export const McpbManifestServerSchema = z
+  .object({
+    type: z.enum(["python", "node", "binary"]),
+    entry_point: z.string(),
+    mcp_config: McpbManifestMcpConfigSchema,
+  })
+  .passthrough();
 
 export const McpbManifestCompatibilitySchema = z
   .object({
@@ -47,31 +55,37 @@ export const McpbManifestCompatibilitySchema = z
   })
   .passthrough();
 
-export const McpbManifestToolSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-});
+export const McpbManifestToolSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestPromptSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  arguments: z.array(z.string()).optional(),
-  text: z.string(),
-});
+export const McpbManifestPromptSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    arguments: z.array(z.string()).optional(),
+    text: z.string(),
+  })
+  .passthrough();
 
-export const McpbUserConfigurationOptionSchema = z.object({
-  type: z.enum(["string", "number", "boolean", "directory", "file"]),
-  title: z.string(),
-  description: z.string(),
-  required: z.boolean().optional(),
-  default: z
-    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
-    .optional(),
-  multiple: z.boolean().optional(),
-  sensitive: z.boolean().optional(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-});
+export const McpbUserConfigurationOptionSchema = z
+  .object({
+    type: z.enum(["string", "number", "boolean", "directory", "file"]),
+    title: z.string(),
+    description: z.string(),
+    required: z.boolean().optional(),
+    default: z
+      .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+      .optional(),
+    multiple: z.boolean().optional(),
+    sensitive: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .passthrough();
 
 export const McpbManifestSchema = z
   .object({

--- a/src/schemas_loose/0.2.ts
+++ b/src/schemas_loose/0.2.ts
@@ -2,22 +2,28 @@ import * as z from "zod";
 
 export const MANIFEST_VERSION = "0.2";
 
-export const McpServerConfigSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+export const McpServerConfigSchema = z
+  .object({
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
 
-export const McpbManifestAuthorSchema = z.object({
-  name: z.string(),
-  email: z.string().email().optional(),
-  url: z.string().url().optional(),
-});
+export const McpbManifestAuthorSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().email().optional(),
+    url: z.string().url().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestRepositorySchema = z.object({
-  type: z.string(),
-  url: z.string().url(),
-});
+export const McpbManifestRepositorySchema = z
+  .object({
+    type: z.string(),
+    url: z.string().url(),
+  })
+  .passthrough();
 
 export const McpbManifestPlatformOverrideSchema =
   McpServerConfigSchema.partial();
@@ -28,11 +34,13 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
     .optional(),
 });
 
-export const McpbManifestServerSchema = z.object({
-  type: z.enum(["python", "node", "binary"]),
-  entry_point: z.string(),
-  mcp_config: McpbManifestMcpConfigSchema,
-});
+export const McpbManifestServerSchema = z
+  .object({
+    type: z.enum(["python", "node", "binary"]),
+    entry_point: z.string(),
+    mcp_config: McpbManifestMcpConfigSchema,
+  })
+  .passthrough();
 
 export const McpbManifestCompatibilitySchema = z
   .object({
@@ -47,31 +55,37 @@ export const McpbManifestCompatibilitySchema = z
   })
   .passthrough();
 
-export const McpbManifestToolSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-});
+export const McpbManifestToolSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestPromptSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  arguments: z.array(z.string()).optional(),
-  text: z.string(),
-});
+export const McpbManifestPromptSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    arguments: z.array(z.string()).optional(),
+    text: z.string(),
+  })
+  .passthrough();
 
-export const McpbUserConfigurationOptionSchema = z.object({
-  type: z.enum(["string", "number", "boolean", "directory", "file"]),
-  title: z.string(),
-  description: z.string(),
-  required: z.boolean().optional(),
-  default: z
-    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
-    .optional(),
-  multiple: z.boolean().optional(),
-  sensitive: z.boolean().optional(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-});
+export const McpbUserConfigurationOptionSchema = z
+  .object({
+    type: z.enum(["string", "number", "boolean", "directory", "file"]),
+    title: z.string(),
+    description: z.string(),
+    required: z.boolean().optional(),
+    default: z
+      .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+      .optional(),
+    multiple: z.boolean().optional(),
+    sensitive: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .passthrough();
 
 export const McpbManifestSchema = z
   .object({

--- a/src/schemas_loose/0.3.ts
+++ b/src/schemas_loose/0.3.ts
@@ -6,22 +6,28 @@ const LOCALE_PLACEHOLDER_REGEX = /\$\{locale\}/i;
 const BCP47_REGEX = /^[A-Za-z0-9]{2,8}(?:-[A-Za-z0-9]{1,8})*$/;
 const ICON_SIZE_REGEX = /^\d+x\d+$/;
 
-export const McpServerConfigSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+export const McpServerConfigSchema = z
+  .object({
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
 
-export const McpbManifestAuthorSchema = z.object({
-  name: z.string(),
-  email: z.string().email().optional(),
-  url: z.string().url().optional(),
-});
+export const McpbManifestAuthorSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().email().optional(),
+    url: z.string().url().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestRepositorySchema = z.object({
-  type: z.string(),
-  url: z.string().url(),
-});
+export const McpbManifestRepositorySchema = z
+  .object({
+    type: z.string(),
+    url: z.string().url(),
+  })
+  .passthrough();
 
 export const McpbManifestPlatformOverrideSchema =
   McpServerConfigSchema.partial();
@@ -32,11 +38,13 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
     .optional(),
 });
 
-export const McpbManifestServerSchema = z.object({
-  type: z.enum(["python", "node", "binary"]),
-  entry_point: z.string(),
-  mcp_config: McpbManifestMcpConfigSchema,
-});
+export const McpbManifestServerSchema = z
+  .object({
+    type: z.enum(["python", "node", "binary"]),
+    entry_point: z.string(),
+    mcp_config: McpbManifestMcpConfigSchema,
+  })
+  .passthrough();
 
 export const McpbManifestCompatibilitySchema = z
   .object({
@@ -51,31 +59,37 @@ export const McpbManifestCompatibilitySchema = z
   })
   .passthrough();
 
-export const McpbManifestToolSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-});
+export const McpbManifestToolSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestPromptSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  arguments: z.array(z.string()).optional(),
-  text: z.string(),
-});
+export const McpbManifestPromptSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    arguments: z.array(z.string()).optional(),
+    text: z.string(),
+  })
+  .passthrough();
 
-export const McpbUserConfigurationOptionSchema = z.object({
-  type: z.enum(["string", "number", "boolean", "directory", "file"]),
-  title: z.string(),
-  description: z.string(),
-  required: z.boolean().optional(),
-  default: z
-    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
-    .optional(),
-  multiple: z.boolean().optional(),
-  sensitive: z.boolean().optional(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-});
+export const McpbUserConfigurationOptionSchema = z
+  .object({
+    type: z.enum(["string", "number", "boolean", "directory", "file"]),
+    title: z.string(),
+    description: z.string(),
+    required: z.boolean().optional(),
+    default: z
+      .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+      .optional(),
+    multiple: z.boolean().optional(),
+    sensitive: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .passthrough();
 
 export const McpbManifestLocalizationSchema = z
   .object({

--- a/src/schemas_loose/0.4.ts
+++ b/src/schemas_loose/0.4.ts
@@ -7,22 +7,28 @@ const LOCALE_PLACEHOLDER_REGEX = /\$\{locale\}/i;
 const BCP47_REGEX = /^[A-Za-z0-9]{2,8}(?:-[A-Za-z0-9]{1,8})*$/;
 const ICON_SIZE_REGEX = /^\d+x\d+$/;
 
-export const McpServerConfigSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()).optional(),
-  env: z.record(z.string(), z.string()).optional(),
-});
+export const McpServerConfigSchema = z
+  .object({
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
 
-export const McpbManifestAuthorSchema = z.object({
-  name: z.string(),
-  email: z.string().email().optional(),
-  url: z.string().url().optional(),
-});
+export const McpbManifestAuthorSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().email().optional(),
+    url: z.string().url().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestRepositorySchema = z.object({
-  type: z.string(),
-  url: z.string().url(),
-});
+export const McpbManifestRepositorySchema = z
+  .object({
+    type: z.string(),
+    url: z.string().url(),
+  })
+  .passthrough();
 
 export const McpbManifestPlatformOverrideSchema =
   McpServerConfigSchema.partial();
@@ -33,12 +39,14 @@ export const McpbManifestMcpConfigSchema = McpServerConfigSchema.extend({
     .optional(),
 });
 
-export const McpbManifestServerSchema = z.object({
-  type: z.enum(["python", "node", "binary", "uv"]),
-  entry_point: z.string(),
-  // mcp_config is optional for UV type (UV handles execution)
-  mcp_config: McpbManifestMcpConfigSchema.optional(),
-});
+export const McpbManifestServerSchema = z
+  .object({
+    type: z.enum(["python", "node", "binary", "uv"]),
+    entry_point: z.string(),
+    // mcp_config is optional for UV type (UV handles execution)
+    mcp_config: McpbManifestMcpConfigSchema.optional(),
+  })
+  .passthrough();
 
 export const McpbManifestCompatibilitySchema = z
   .object({
@@ -53,31 +61,37 @@ export const McpbManifestCompatibilitySchema = z
   })
   .passthrough();
 
-export const McpbManifestToolSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-});
+export const McpbManifestToolSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
 
-export const McpbManifestPromptSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  arguments: z.array(z.string()).optional(),
-  text: z.string(),
-});
+export const McpbManifestPromptSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    arguments: z.array(z.string()).optional(),
+    text: z.string(),
+  })
+  .passthrough();
 
-export const McpbUserConfigurationOptionSchema = z.object({
-  type: z.enum(["string", "number", "boolean", "directory", "file"]),
-  title: z.string(),
-  description: z.string(),
-  required: z.boolean().optional(),
-  default: z
-    .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
-    .optional(),
-  multiple: z.boolean().optional(),
-  sensitive: z.boolean().optional(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-});
+export const McpbUserConfigurationOptionSchema = z
+  .object({
+    type: z.enum(["string", "number", "boolean", "directory", "file"]),
+    title: z.string(),
+    description: z.string(),
+    required: z.boolean().optional(),
+    default: z
+      .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+      .optional(),
+    multiple: z.boolean().optional(),
+    sensitive: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .passthrough();
 
 export const McpbManifestLocalizationSchema = z
   .object({

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 import { v0_2, v0_3 } from "../src/schemas/index.js";
+import { v0_4 as loose0_4 } from "../src/schemas_loose/index.js";
 
 describe("McpbManifestSchema", () => {
   it("should validate a valid manifest", () => {
@@ -333,6 +334,46 @@ describe("McpbManifestSchema", () => {
       };
       const result = v0_3.McpbManifestSchema.safeParse(manifest);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("loose schema preserves unknown nested keys (cleanMcpb)", () => {
+    it("keeps unknown keys nested inside author, server, and mcp_config", () => {
+      const manifest = {
+        manifest_version: "0.4",
+        name: "ext",
+        version: "1.0.0",
+        description: "desc",
+        author: { name: "A", twitter: "@a" },
+        server: {
+          type: "node",
+          entry_point: "server.js",
+          custom_server_field: "keep-me",
+          mcp_config: {
+            command: "node",
+            args: ["server.js"],
+            extra_exec_opt: "keep-me-too",
+          },
+        },
+        top_level_unknown: "kept",
+      };
+
+      const result = loose0_4.McpbManifestSchema.safeParse(manifest);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as unknown as {
+          top_level_unknown: unknown;
+          author: { twitter: unknown };
+          server: {
+            custom_server_field: unknown;
+            mcp_config: { extra_exec_opt: unknown };
+          };
+        };
+        expect(data.top_level_unknown).toBe("kept");
+        expect(data.author.twitter).toBe("@a");
+        expect(data.server.custom_server_field).toBe("keep-me");
+        expect(data.server.mcp_config.extra_exec_opt).toBe("keep-me-too");
+      }
     });
   });
 });


### PR DESCRIPTION
## Problem

The loose schemas exist to validate a manifest while **preserving** unrecognised data, but `.passthrough()` was applied only to the root object. Nested `z.object()` schemas strip unknown keys by default, and `cleanMcpb` rewrites the manifest with the loose parse result (`result.data`) — so `mcpb clean` silently **deletes** any custom field nested under `author`, `server`, `server.mcp_config`, `repository`, tools, prompts, or user_config options.

Fixes #264.

## Fix

Add `.passthrough()` to the nested object schemas across all loose versions (0.1–0.4): `McpServerConfigSchema`, `McpbManifestAuthorSchema`, `McpbManifestRepositorySchema`, `McpbManifestServerSchema`, `McpbManifestToolSchema`, `McpbManifestPromptSchema`, `McpbUserConfigurationOptionSchema`. `.extend()`/`.partial()` derivatives inherit `unknownKeys`, so `McpbManifestMcpConfigSchema` and `McpbManifestPlatformOverrideSchema` are covered via `McpServerConfigSchema` (verified). The `localization`/`icon` sub-schemas already had `.passthrough()`.

## Test

Adds a case to `test/schemas.test.ts`: unknown keys nested in `author`, `server`, and `server.mcp_config` survive a loose 0.4 parse. Fails against the old schema, passes with the fix. `yarn lint` + `yarn test` (schemas/config suites) green.

_Note: `validate`/`cli`/`icon-validation` suites fail in a bare checkout without a build in my environment — they're unrelated to this change and pass in CI._