### PR TITLE
Drop platform_overrides from resolved mcp_config; honour empty-string overrides

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -115,12 +115,21 @@ export async function getMcpConfigForManifest(
     if (process.platform in baseConfig.platform_overrides) {
       const platformConfig = baseConfig.platform_overrides[process.platform];
 
-      result.command = platformConfig.command || result.command;
-      result.args = platformConfig.args || result.args;
+      // Use explicit presence checks so a deliberate empty-string command (or
+      // empty args) override is honoured rather than falling back to the base.
+      result.command =
+        platformConfig.command !== undefined
+          ? platformConfig.command
+          : result.command;
+      result.args =
+        platformConfig.args !== undefined ? platformConfig.args : result.args;
       result.env = platformConfig.env
         ? { ...result.env, ...platformConfig.env }
         : result.env;
     }
+    // platform_overrides is a build-time directive; it must not leak into the
+    // resolved runtime mcp_config handed to the host.
+    delete result.platform_overrides;
   }
 
   // Check if required configuration is missing

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -200,6 +200,70 @@ describe("getMcpConfigForManifest", () => {
 
     expect(result?.command).toBe("platform-command");
     expect(result?.args).toEqual(["platform-specific"]);
+    // platform_overrides must not leak into the resolved runtime config.
+    expect(result?.platform_overrides).toBeUndefined();
+  });
+
+  it("should not leak platform_overrides into the resolved config", async () => {
+    const manifest: McpbManifestAny = {
+      ...baseManifest,
+      server: {
+        type: "node",
+        entry_point: "server.js",
+        mcp_config: {
+          command: "default-command",
+          args: ["default"],
+          platform_overrides: {
+            // An override for a platform that is NOT the current one.
+            [process.platform === "win32" ? "darwin" : "win32"]: {
+              command: "other-platform-command",
+            },
+          },
+        },
+      },
+    };
+
+    const result = await getMcpConfigForManifest({
+      manifest,
+      extensionPath: "/ext/path",
+      systemDirs: mockSystemDirs,
+      userConfig: {},
+      pathSeparator: "/",
+      logger: mockLogger,
+    });
+
+    expect(result?.command).toBe("default-command");
+    expect(result?.platform_overrides).toBeUndefined();
+  });
+
+  it("should honour an empty-string command platform override", async () => {
+    const manifest: McpbManifestAny = {
+      ...baseManifest,
+      server: {
+        type: "node",
+        entry_point: "server.js",
+        mcp_config: {
+          command: "default-command",
+          args: ["default"],
+          platform_overrides: {
+            [process.platform]: {
+              command: "",
+            },
+          },
+        },
+      },
+    };
+
+    const result = await getMcpConfigForManifest({
+      manifest,
+      extensionPath: "/ext/path",
+      systemDirs: mockSystemDirs,
+      userConfig: {},
+      pathSeparator: "/",
+      logger: mockLogger,
+    });
+
+    expect(result?.command).toBe("");
   });
 
   it("should handle user config variable replacement with defaults", async () => {


### PR DESCRIPTION
## Problems

1. **platform_overrides leaks into the resolved config (#265).** `getMcpConfigForManifest` builds `result` by spreading the base `mcp_config` (which includes `platform_overrides`), applies the current platform's overrides, but never removes the `platform_overrides` map — so the resolved runtime config handed to the host still carries the entire block, including other platforms' commands/env.
2. **Empty-string command override is dropped (item 1 of #267).** `result.command = platformConfig.command || result.command` uses `||`, so a deliberate empty-string override is falsy and falls back to the base command.

## Fix

- `delete result.platform_overrides` after resolving (`src/shared/config.ts`).
- Use explicit `!== undefined` presence checks for the `command`/`args` override merge.

## Test

Adds cases to `test/config.test.ts`: the resolved config has no `platform_overrides` (incl. when an override exists for a non-current platform), and an empty-string command override is honoured. New assertions fail against the old code and pass with the fix. `yarn lint` + `yarn test` (config suite) green.

Fixes #265.